### PR TITLE
Fix for OpenCV 4.2

### DIFF
--- a/src/surface_normal.cpp
+++ b/src/surface_normal.cpp
@@ -45,7 +45,7 @@ Mat1f get_surrounding_points(const Mat1f &depth, int i, int j, CameraIntrinsics 
 Vec3f fit_plane(const Mat &points) {
   constexpr int ncols = 3;
   Mat cov, centroid;
-  calcCovarMatrix(points, cov, centroid, CV_COVAR_ROWS | CV_COVAR_NORMAL, CV_32F);
+  calcCovarMatrix(points, cov, centroid, COVAR_ROWS | COVAR_NORMAL, CV_32F);
   SVD svd(cov, SVD::MODIFY_A);
   // Assign plane coefficients by the singular vector corresponding to the smallest
   // singular value.


### PR DESCRIPTION
The latest OpenCV on Anaconda is 4.2, and some flags like `cv::CV_COVAR_ROWS` flag have become `cv::COVAR_ROWS` (so it doesn't compile anymore)

Have you thought about making a pull request for the original repo? It might make your updated code more visible